### PR TITLE
Fix listener leak in useToast hook

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix useToast hook to avoid registering duplicate listeners

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434d7e85288325b48a71ad682fabb1