### PR TITLE
Fix employee creation handling

### DIFF
--- a/components/attendance-form.tsx
+++ b/components/attendance-form.tsx
@@ -507,7 +507,7 @@ export function AttendanceForm() {
           },
         ];
 
-        const { data: createdEmployees } = await fetch("/api/employees", {
+        const createdEmployeesData = await fetch("/api/employees", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -515,7 +515,11 @@ export function AttendanceForm() {
           body: JSON.stringify(testEmployees),
         }).then((res) => res.json());
 
-        if (!createdEmployees || createdEmployees.length === 0) {
+        const createdEmployees = Array.isArray(createdEmployeesData)
+          ? createdEmployeesData
+          : [createdEmployeesData];
+
+        if (createdEmployees.length === 0) {
           throw new Error("Erro ao criar funcionários de teste");
         }
 
@@ -566,7 +570,7 @@ export function AttendanceForm() {
           },
         ];
 
-        const { data: createdEmployees } = await fetch("/api/employees", {
+        const createdEmployeesData = await fetch("/api/employees", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -574,7 +578,11 @@ export function AttendanceForm() {
           body: JSON.stringify(testEmployees),
         }).then((res) => res.json());
 
-        if (!createdEmployees || createdEmployees.length === 0) {
+        const createdEmployees = Array.isArray(createdEmployeesData)
+          ? createdEmployeesData
+          : [createdEmployeesData];
+
+        if (createdEmployees.length === 0) {
           throw new Error("Erro ao criar funcionários de teste");
         }
 


### PR DESCRIPTION
## Summary
- handle InitializeData API returning single employee object

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68435187ff088325ba85ae7cd2407871