### PR TITLE
Add Jest setup and fetcher tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};
+
+export default config;

--- a/lib/__tests__/fetcher.test.ts
+++ b/lib/__tests__/fetcher.test.ts
@@ -1,0 +1,29 @@
+import { fetcher } from '../fetcher';
+
+describe('fetcher', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  it('returns json on ok response', async () => {
+    const data = { message: 'ok' };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    } as any);
+
+    await expect(fetcher('https://example.com')).resolves.toEqual(data);
+  });
+
+  it('throws with message from body on error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve('bad request'),
+    } as any);
+
+    await expect(fetcher('https://example.com')).rejects.toThrow('bad request');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "jest",
     "prisma:generate": "prisma generate",
     "prisma:push": "prisma db push",
     "prisma:seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
@@ -51,7 +52,10 @@
     "prisma": "^5.10.2",
     "tailwindcss": "^3.3.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29.5.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"


### PR DESCRIPTION
## Summary
- add `test` script and Jest dev dependencies
- configure Jest with ts-jest
- add tests for `fetcher`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843529e46d0832582f3bec2529c74c7